### PR TITLE
Small fix to make the lines pixel-perfect in chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@ background-size: 100px 100px;
 background-color: #EC173A;" title="Zig-Zag" data-author="eCSSpert" data-author-url="http://twitter.com/ecsspert"></li>
 
 	<li style="background:
-linear-gradient(135deg, #708090 22px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px),
-linear-gradient(225deg, #708090 22px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px)0 64px;
+linear-gradient(135deg, #708090 21px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px),
+linear-gradient(225deg, #708090 21px, #d9ecff 22px, #d9ecff 24px, transparent 24px, transparent 67px, #d9ecff 67px, #d9ecff 69px, transparent 69px)0 64px;
 background-color:#708090;
 background-size: 64px 128px" title="Weave" data-author="Jeroen Franse" data-author-url="http://twitter.com/jroenf"></li>
 


### PR DESCRIPTION
When looking at the pattern in Chrome 49, you'll notice that the small
sides are less wide than the other lines. You won't see this in IE and
this change does nothing for IE (must be a rounding issue), however,
using this updated style will make sure Chrome renders it the same as IE
(and just looks better).
